### PR TITLE
Docs: Update web runtime quickstart docs to reference new web package

### DIFF
--- a/runtimes/overview.md
+++ b/runtimes/overview.md
@@ -8,24 +8,24 @@ Rive's runtimes are open source and can be downloaded from GitHub, or through re
 
 ## Official runtimes
 
-| Runtime | Link |
-| :--- | :--- |
-| Web | ​[npm](https://www.npmjs.com/package/rive-js), [GitHub](https://github.com/rive-app/rive-wasm)​ |
-| React | [npm](https://www.npmjs.com/package/rive-react), [GitHub](https://github.com/rive-app/rive-react) |
-| iOS | [GitHub](https://github.com/rive-app/rive-ios) |
-| Android | [maven](https://search.maven.org/artifact/app.rive/rive-android), [GitHub](https://github.com/rive-app/rive-android) |
-| Flutter | ​[pub.dev](https://pub.dev/packages/rive), [GitHub](https://github.com/rive-app/rive-flutter)​ |
-| C++ | ​[GitHub](https://github.com/rive-app/rive-cpp) |
-| Tizen | [GitHub](https://github.com/rive-app/rive-tizen) |
-| React Native | [GitHub](https://github.com/rive-app/rive-react-native) |
+| Runtime      | Link                                                                                                                                                                                                                                                                                                                                        |
+| :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Web          | ​[webgl npm](https://www.npmjs.com/package/@rive-app/webgl), ​[webgl-advanced npm](https://www.npmjs.com/package/@rive-app/webgl-advanced), [canvas npm](https://www.npmjs.com/package/@rive-app/canvas), ​[canvas-advanced npm](https://www.npmjs.com/package/@rive-app/canvas-advanced), [GitHub](https://github.com/rive-app/rive-wasm)​ |
+| React        | [npm](https://www.npmjs.com/package/rive-react), [GitHub](https://github.com/rive-app/rive-react)                                                                                                                                                                                                                                           |
+| iOS          | [GitHub](https://github.com/rive-app/rive-ios)                                                                                                                                                                                                                                                                                              |
+| Android      | [maven](https://search.maven.org/artifact/app.rive/rive-android), [GitHub](https://github.com/rive-app/rive-android)                                                                                                                                                                                                                        |
+| Flutter      | ​[pub.dev](https://pub.dev/packages/rive), [GitHub](https://github.com/rive-app/rive-flutter)​                                                                                                                                                                                                                                              |
+| C++          | ​[GitHub](https://github.com/rive-app/rive-cpp)                                                                                                                                                                                                                                                                                             |
+| Tizen        | [GitHub](https://github.com/rive-app/rive-tizen)                                                                                                                                                                                                                                                                                            |
+| React Native | [GitHub](https://github.com/rive-app/rive-react-native)                                                                                                                                                                                                                                                                                     |
 
 ## Community runtimes
 
-| Runtime | Author | Link |
-| :--- | :--- | :--- |
-| Vue.js | Dan Nelson | [GitHub](https://github.com/Coded-Clouds/Rive_Vue_ExampleApp) |
-| Angular | François Guezengar | [GitHub](https://github.com/dappsnation/ng-rive) |
-| AWTK | [Li XianJing](https://twitter.com/xianjimli) | [GitHub](https://github.com/zlgopen/awtk-widget-rive) |
+| Runtime | Author                                       | Link                                                          |
+| :------ | :------------------------------------------- | :------------------------------------------------------------ |
+| Vue.js  | Dan Nelson                                   | [GitHub](https://github.com/Coded-Clouds/Rive_Vue_ExampleApp) |
+| Angular | François Guezengar                           | [GitHub](https://github.com/dappsnation/ng-rive)              |
+| AWTK    | [Li XianJing](https://twitter.com/xianjimli) | [GitHub](https://github.com/zlgopen/awtk-widget-rive)         |
 
 ## Licensing
 
@@ -40,4 +40,3 @@ Since all the runtimes are open-source, we encourage you to dive in and take a l
 As we publish updates to our Rive editor, we will occasionally push updated runtimes to support the new features. In most cases, the newest runtimes will also support previous versions of your Rive assets, so you will not need to re-export assets to update to the latest runtimes.
 
 There are a number of ways to export your Rive files in cases where re-exporting is necessary to take advantage of the latest features. Check out our documentation on [exporting](../editor/exporting.md) for more information.
-

--- a/runtimes/quick-start.md
+++ b/runtimes/quick-start.md
@@ -8,66 +8,94 @@ description: >-
 
 {% tabs %}
 {% tab title="Web" %}
+
 ## 1. Add the Rive library
 
 Add a script tag to a web page:
 
-```javascript
-<script src="https://unpkg.com/rive-js"></script>
+```html
+<script src="https://unpkg.com/@rive-app/webgl"></script>
 ```
+
+Alternatively, you can import our recommended web runtime package via NPM in your project:
+
+```javascript
+npm install @rive-app/webgl
+
+// example.js
+import rive from "@rive-app/webgl";
+```
+
+If you need more details and options for a web runtime, checkout the installation section in the [README](https://github.com/rive-app/rive-wasm#installing) docs.
 
 ## 2. Create a canvas
 
-Create a canvas where you want the Rive file to display:
+Create a canvas element where you want the Rive file to display in your HTML:
 
-```javascript
+```html
 <canvas id="canvas" width="500" height="500"></canvas>
 ```
 
 ## 3. Create a Rive object
 
-Create a new instance of a Rive object, providing the url of the Rive file you wish to show, the canvas on which you want it to render, and whether you want the default animation to play.
+Create a new instance of a Rive object, providing the following properties:
 
-```javascript
+- `src` - A string of the URL where the `.riv` file is hosted (like in the example below), or the path to a local `.riv` file
+- `canvas` - The canvas element on which you want the animation to render
+- `autoplay` - Boolean for whether you want the default animation to play
+
+```html
 <script>
-    new rive.Rive({
-        src: 'https://cdn.rive.app/animations/vehicles.riv',
-        canvas: document.getElementById('canvas'),
-        autoplay: true
-    });
+  new rive.Rive({
+    src: "https://cdn.rive.app/animations/vehicles.riv",
+    // Or the path to a local Rive asset
+    // src: './example.riv',
+    canvas: document.getElementById("canvas"),
+    autoplay: true
+  });
 </script>
 ```
 
 ## Complete example
 
-```javascript
-<html>
-    <head>
-        <title>Rive Hello World</title>
-    </head>
-    <body>
-        <canvas id="canvas" width="500" height="500"></canvas>
+Putting this altogether, you can load this example Rive animation in one HTML file:
 
-        <script src="https://unpkg.com/rive-js"></script>
-        <script>
-            new rive.Rive({
-                src: 'https://cdn.rive.app/animations/vehicles.riv',
-                canvas: document.getElementById('canvas'),
-                autoplay: true
-            });
-        </script>
-    </body>
+```html
+<html>
+  <head>
+    <title>Rive Hello World</title>
+  </head>
+  <body>
+    <canvas id="canvas" width="500" height="500"></canvas>
+
+    <script src="https://unpkg.com/@rive-app/webgl"></script>
+    <script>
+      new rive.Rive({
+        src: "https://cdn.rive.app/animations/vehicles.riv",
+        canvas: document.getElementById("canvas"),
+        autoplay: true
+      });
+    </script>
+  </body>
 </html>
 ```
+
+**Try it out on your own:** Check out this [CodeSandbox](https://codesandbox.io/s/rive-plain-js-sandbox-1ddrc?file=/src/index.js) for a small setup to test your own Rive files in!
+
+**API Docs:** Check out the web runtime [README docs](https://github.com/rive-app/rive-wasm#readme) for more on what you can do with the Rive API.
+
 {% endtab %}
 
 {% tab title="React" %}
+
 ## Install the rive-react package
 
 {% code title="" %}
+
 ```bash
 npm i --save rive-react
 ```
+
 {% endcode %}
 
 ## Component
@@ -75,7 +103,7 @@ npm i --save rive-react
 Rive React provides a basic component as it's default import for displaying simple animations.
 
 ```javascript
-import Rive from 'rive-react'
+import Rive from "rive-react";
 
 export const Simple = () => (
   <Rive src="https://cdn.rive.app/animations/vehicles.riv" />
@@ -84,23 +112,23 @@ export const Simple = () => (
 
 ### Props
 
-* `src`: File path or URL to the .riv file to display.
-* `artboard`: _(optional)_ Name to display.
-* `animations`: _(optional)_ Name or list of names of animtions to play.
-* `layout`: _(optional)_ Layout object to define how animations are displayed on the canvas.
-* _All attributes and eventHandlers that can be passed to a `div` element can also be passed to the `Rive` component and used in the same manner._
+- `src`: File path or URL to the .riv file to display.
+- `artboard`: _(optional)_ Name to display.
+- `animations`: _(optional)_ Name or list of names of animtions to play.
+- `layout`: _(optional)_ Layout object to define how animations are displayed on the canvas.
+- _All attributes and eventHandlers that can be passed to a `div` element can also be passed to the `Rive` component and used in the same manner._
 
 ## useRive Hook
 
 For more advanced usage, the `useRive` hook is provided. The hook will return a component and a `Rive` object which gives you control of the current rive file.
 
 ```javascript
-import { useRive } from 'rive-react';
+import { useRive } from "rive-react";
 
 export default function Simple() {
   const { rive, RiveComponent } = useRive({
-    src: 'https://cdn.rive.app/animations/vehicles.riv',
-    autoplay: false,
+    src: "https://cdn.rive.app/animations/vehicles.riv",
+    autoplay: false
   });
 
   return (
@@ -114,41 +142,41 @@ export default function Simple() {
 
 ### Parameters
 
-* `riveParams`: Set of parameters that are passed to the Rive.js `Rive` class constructor. `null` and `undefined` can be passed to conditionally display the .riv file.
-* `opts`: Rive React specific options.
+- `riveParams`: Set of parameters that are passed to the Rive.js `Rive` class constructor. `null` and `undefined` can be passed to conditionally display the .riv file.
+- `opts`: Rive React specific options.
 
 ### Return Values
 
-* `RiveComponent`: A Component that can be used to display your .riv file. This component accepts the same attributes and event handlers as a `div` element.
-* `rive`: A Rive.js `Rive` object. This will return as null until the .riv file has fully loaded.
-* `canvas`: HTMLCanvasElement object, on which the .riv file is rendering.
-* `setCanvasRef`: A callback ref that can be passed to your own canvas element, if you wish to have control over the rendering of the Canvas element.
-*   `setContainerRef`: A callback ref that can be passed to a container element that wraps the canvas element, if you which to have control over the rendering of the container element.
+- `RiveComponent`: A Component that can be used to display your .riv file. This component accepts the same attributes and event handlers as a `div` element.
+- `rive`: A Rive.js `Rive` object. This will return as null until the .riv file has fully loaded.
+- `canvas`: HTMLCanvasElement object, on which the .riv file is rendering.
+- `setCanvasRef`: A callback ref that can be passed to your own canvas element, if you wish to have control over the rendering of the Canvas element.
+- `setContainerRef`: A callback ref that can be passed to a container element that wraps the canvas element, if you which to have control over the rendering of the container element.
 
-    _For the vast majority of use cases, you can just the returned `RiveComponent` and don't need to worry about `setCanvasRef` and `setContainerRef`._
+  _For the vast majority of use cases, you can just the returned `RiveComponent` and don't need to worry about `setCanvasRef` and `setContainerRef`._
 
 ### riveParams
 
-* `src?`: _(optional)_ File path or URL to the .riv file to use. One of `src` or `buffer` must be provided.
-* `buffer?`: _(optional)_ ArrayBuffer containing the raw bytes from a .riv file. One of `src` or `buffer` must be provided.
-* `artboard?`: _(optional)_ Name of the artboard to use.
-* `animations?`: _(optional)_ Name or list of names of animations to play.
-* `stateMachines?`: _(optional)_ Name of list of names of state machines to load.
-* `layout?`: _(optional)_ Layout object to define how animations are displayed on the canvas. See [Rive.js](https://github.com/rive-app/rive-wasm#layout) for more details.
-* `autoplay?`: _(optional)_ If `true`, the animation will automatically start playing when loaded. Defaults to false.
-* `onLoad?`: _(optional)_ Callback that get's fired when the .rive file loads .
-* `onLoadError?`: _(optional)_ Callback that get's fired when an error occurs loading the .riv file.
-* `onPlay?`: _(optional)_ Callback that get's fired when the animation starts playing.
-* `onPause?`: _(optional)_ Callback that get's fired when the animation pauses.
-* `onStop?`: _(optional)_ Callback that get's fired when the animation stops playing.
-* `onLoop?`: _(optional)_ Callback that get's fired when the animation completes a loop.
-* `onStateChange?`: _(optional)_ Callback that get's fired when a state change occurs.
+- `src?`: _(optional)_ File path or URL to the .riv file to use. One of `src` or `buffer` must be provided.
+- `buffer?`: _(optional)_ ArrayBuffer containing the raw bytes from a .riv file. One of `src` or `buffer` must be provided.
+- `artboard?`: _(optional)_ Name of the artboard to use.
+- `animations?`: _(optional)_ Name or list of names of animations to play.
+- `stateMachines?`: _(optional)_ Name of list of names of state machines to load.
+- `layout?`: _(optional)_ Layout object to define how animations are displayed on the canvas. See [web runtime docs](https://github.com/rive-app/rive-wasm#layout) for more details.
+- `autoplay?`: _(optional)_ If `true`, the animation will automatically start playing when loaded. Defaults to false.
+- `onLoad?`: _(optional)_ Callback that get's fired when the .rive file loads .
+- `onLoadError?`: _(optional)_ Callback that get's fired when an error occurs loading the .riv file.
+- `onPlay?`: _(optional)_ Callback that get's fired when the animation starts playing.
+- `onPause?`: _(optional)_ Callback that get's fired when the animation pauses.
+- `onStop?`: _(optional)_ Callback that get's fired when the animation stops playing.
+- `onLoop?`: _(optional)_ Callback that get's fired when the animation completes a loop.
+- `onStateChange?`: _(optional)_ Callback that get's fired when a state change occurs.
 
 ### opts
 
-* `useDevicePixelRatio`: _(optional)_ If `true`, the hook will scale the resolution of the animation based the [devicePixelRatio](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio). Defaults to `true`. NOTE: Requires the `setContainerRef` ref callback to be passed to a element wrapping a canvas element. If you use the `RiveComponent`, then this will happen automatically.
-* `fitCanvasToArtboardHeight`: _(optional)_ If `true`, then the canvas will resize based on the height of the artboard. Defaults to `false`.
-{% endtab %}
+- `useDevicePixelRatio`: _(optional)_ If `true`, the hook will scale the resolution of the animation based the [devicePixelRatio](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio). Defaults to `true`. NOTE: Requires the `setContainerRef` ref callback to be passed to a element wrapping a canvas element. If you use the `RiveComponent`, then this will happen automatically.
+- `fitCanvasToArtboardHeight`: _(optional)_ If `true`, then the canvas will resize based on the height of the artboard. Defaults to `false`.
+  {% endtab %}
 
 {% tab title="Vue" %}
 The following snippet demonstrates how to create a simple Rive component in [Vue](https://vuejs.org) 2.
@@ -161,7 +189,7 @@ The following snippet demonstrates how to create a simple Rive component in [Vue
 </template>
 
 <script>
-import { Rive, Layout } from 'rive-js'
+import { Rive, Layout } from '@rive-app/webgl';
 
 export default {
   name: 'Rive',
@@ -184,16 +212,20 @@ export default {
 }
 </script>
 ```
+
 {% endtab %}
 
 {% tab title="Flutter" %}
+
 ## 1. Add the Rive package dependency
 
 {% code title="pubspec.yaml" %}
+
 ```yaml
 dependencies:
   rive:
 ```
+
 {% endcode %}
 
 ## 2. Import the Rive package
@@ -213,6 +245,7 @@ RiveAnimation.network(
 ## Complete example
 
 {% code title="main.dart" %}
+
 ```dart
 import 'package:flutter/material.dart';
 import 'package:rive/rive.dart';
@@ -235,16 +268,20 @@ class MyRiveAnimation extends StatelessWidget {
   }
 }
 ```
+
 {% endcode %}
 {% endtab %}
 
 {% tab title="iOS" %}
+
 ## 1. Add the CocoaPods dependency
 
 {% code title="Podfile" %}
+
 ```ruby
   pod 'RiveRuntime', :git => 'git@github.com:rive-app/test-ios.git'
 ```
+
 {% endcode %}
 
 ## 2. Create a UIViewController and import runtime
@@ -292,9 +329,11 @@ override public func viewDidDisappear(_ animated: Bool) {
     super.viewDidDisappear(animated)
 }
 ```
+
 {% endtab %}
 
 {% tab title="Android" %}
+
 ## 1. Add the Rive dependency
 
 ```groovy
@@ -319,6 +358,7 @@ dependencies {
 ## 3. Clean up when done
 
 {% code title="MyRiveActivity.kt" %}
+
 ```kotlin
 class MyRiveActivity : AppCompatActivity() {
 
@@ -337,6 +377,7 @@ class MyRiveActivity : AppCompatActivity() {
     }
 }
 ```
+
 {% endcode %}
 
 ## Internet permissions
@@ -344,16 +385,19 @@ class MyRiveActivity : AppCompatActivity() {
 This example requires your app to have permission to access the internet:
 
 {% code title="AndroidManifest.xml" %}
+
 ```markup
 <uses-permission android:name="android.permission.INTERNET" />
 <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 ```
+
 {% endcode %}
 
 This is needed only if you're retrieving Rive files over a network. If you include the files in your Android project, this isn't necessary.
 {% endtab %}
 
 {% tab title="React Native" %}
+
 ## 1. Add the Rive dependency
 
 ```bash
@@ -362,27 +406,32 @@ npm install --save rive-react-native
 
 ## 2. Create iOS bridging header
 
-* open the iOS project file in XCode `open ios/<name>.xcodeproj`
-* create a new empty swift file.&#x20;
-* confirm "Create Bridging Header"
+- open the iOS project file in XCode `open ios/<name>.xcodeproj`
+- create a new empty swift file.&#x20;
+- confirm "Create Bridging Header"
 
 ## 3. Add your rive component
 
 {% code title="App.js" %}
+
 ```javascript
-import Rive from 'rive-react-native';
+import Rive from "rive-react-native";
 
 function App() {
-  return <Rive
+  return (
+    <Rive
       url="https://cdn.rive.app/animations/vehicles.riv"
-      style={{width: 400, height: 400}}
-  />;
+      style={{ width: 400, height: 400 }}
+    />
+  );
 }
 ```
+
 {% endcode %}
 {% endtab %}
 
 {% tab title="Angular" %}
+
 ## 1. Install :
 
 ```
@@ -392,18 +441,17 @@ npm install ng-rive
 ## 2. Import `RiveModule`:
 
 {% code title="animation.module.ts" %}
+
 ```typescript
-import { RiveModule } from 'ng-rive';
+import { RiveModule } from "ng-rive";
 
 @NgModule({
   declarations: [AnimationComponent],
-  imports: [
-    CommonModule,
-    RiveModule,
-  ],
+  imports: [CommonModule, RiveModule]
 })
-export class AnimationModule { }
+export class AnimationModule {}
 ```
+
 {% endcode %}
 
 ## 3. Add your .riv file in your assets
@@ -417,11 +465,13 @@ export class AnimationModule { }
 ## 4. Use in template :
 
 {% code title="animation.component.html" %}
+
 ```markup
 <canvas riv="vehicles" width="500" height="500">
   <riv-animation name="idle" play></riv-animation>
 </canvas>
 ```
+
 {% endcode %}
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
Looking to make 2 updates here:
1. Updating the overview file to reflect the separated web runtime packages
2. Revisted the quickstart docs for the web tab specifically, and removing references to `rive-js`

The Prettier plugin on my VSCode editor formatted the touched markdown files with its own format opinions. I can strip that out, if we want to though.